### PR TITLE
feat(show): コメント表示領域をマウスホバーで拡大するように変更

### DIFF
--- a/css/show.css
+++ b/css/show.css
@@ -22,9 +22,16 @@ td{
 #commentLog{
   margin-left: auto;
   width: 20%;
-  height: 35%;
+  max-height: 35%;
   overflow-y:auto;
   visibility: visible;
+  transition: all 0.5s 0s ease;
+}
+
+#commentLog:hover{
+  width:90%;
+  max-height:90%;
+  background-color: rgba(255, 255, 255, 0.9);
 }
 
 


### PR DESCRIPTION
- マウスホバー時にコメント領域を拡大
- 拡大時に背景を白に変更

長いコメントを読むときに読みづらそうにしていたのと、見ている側も読みづらかったのでので改良してみました。
OBS内でも対話モードを使用すればマウスホバーで大きくなります。

https://user-images.githubusercontent.com/47011206/178408294-554de253-83db-4510-bb81-677b2232a5eb.mp4

